### PR TITLE
Update JNE reference in Loader.java to match pom.xml change in c33f9d83

### DIFF
--- a/src/main/java/kyotocabinet/Loader.java
+++ b/src/main/java/kyotocabinet/Loader.java
@@ -20,7 +20,7 @@ package kyotocabinet;
  * #L%
  */
 
-import com.mfizz.jne.JNE;
+import com.fizzed.jne.JNE;
 
 /**
  * Replaced default Kyoto Loader.java with this one that uses JNE for loading


### PR DESCRIPTION
Sorry, this should have been part of my previous pull request in 2018, but somehow I made this change only locally and didn't get it in there back then...

Also thanks for making kyotocabinet so much more convenient to use than it would be otherwise :)